### PR TITLE
Added WithAllTraceOptions() and renamed TraceAll to AllTraceOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ var (
 )
 
 // Register our ocsql wrapper for the provided SQLite3 driver.
-driverName, err = ocsql.Register("sqlite3", ocsql.WithOptions(ocsql.TraceAll))
+driverName, err = ocsql.Register("sqlite3", ocsql.WithAllTraceOptions())
 if err != nil {
     log.Fatalf("unable to register our ocsql driver: %v\n", err)
 }

--- a/options.go
+++ b/options.go
@@ -50,8 +50,15 @@ type TraceOptions struct {
 	QueryParams bool
 }
 
-// TraceAll has all tracing options enabled.
-var TraceAll = TraceOptions{
+// WithAllTraceOptions enables all available trace options.
+func WithAllTraceOptions() TraceOption {
+	return func(o *TraceOptions) {
+		*o = AllTraceOptions
+	}
+}
+
+// AllTraceOptions has all tracing options enabled.
+var AllTraceOptions = TraceOptions{
 	AllowRoot:    true,
 	Transaction:  true,
 	Ping:         true,


### PR DESCRIPTION
To avoid potential confusion on what TraceAll entails, I've renamed it to AllTraceOptions and provided a convenience functional option `WithAllTraceOptions()`