### PR TITLE
Added WithDefaultAttributes()

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -347,7 +347,11 @@ func (c *ocConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx,
 
 	var span *trace.Span
 	attrs := append([]trace.Attribute(nil), c.options.DefaultAttributes...)
-	defer span.AddAttributes(attrs...)
+	defer func() {
+		if len(attrs) > 0 {
+			span.AddAttributes(attrs...)
+		}
+	}()
 	if ctx == nil || ctx == context.TODO() {
 		ctx = context.Background()
 		_, span = trace.StartSpan(ctx, "sql:begin_transaction")

--- a/options.go
+++ b/options.go
@@ -1,5 +1,9 @@
 package ocsql
 
+import (
+	"go.opencensus.io/trace"
+)
+
 // TraceOption allows for managing ocsql configuration using functional options.
 type TraceOption func(o *TraceOptions)
 
@@ -43,6 +47,9 @@ type TraceOptions struct {
 	// parameters recorded with respect to security.
 	// This setting is a noop if the Query option is set to false.
 	QueryParams bool
+
+	// DefaultAttributes will be set to each span as default.
+	DefaultAttributes []trace.Attribute
 }
 
 // WithAllTraceOptions enables all available trace options.
@@ -137,5 +144,12 @@ func WithQuery(b bool) TraceOption {
 func WithQueryParams(b bool) TraceOption {
 	return func(o *TraceOptions) {
 		o.QueryParams = b
+	}
+}
+
+// WithDefaultAttributes will be set to each span as default.
+func WithDefaultAttributes(attrs ...trace.Attribute) TraceOption {
+	return func(o *TraceOptions) {
+		o.DefaultAttributes = append(o.DefaultAttributes, attrs...)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -150,6 +150,6 @@ func WithQueryParams(b bool) TraceOption {
 // WithDefaultAttributes will be set to each span as default.
 func WithDefaultAttributes(attrs ...trace.Attribute) TraceOption {
 	return func(o *TraceOptions) {
-		o.DefaultAttributes = append(o.DefaultAttributes, attrs...)
+		o.DefaultAttributes = attrs
 	}
 }


### PR DESCRIPTION
## WHY

I'm trying to send the tracing span with [opencensus-go-exporter-datadog](https://github.com/DataDog/opencensus-go-exporter-datadog). DataDog UI has 4 buttons that filter by the span type. By default, the span type will be set `Custom` in *opencensus-go-exporter-datadog*.

<img width="358" alt="image" src="https://user-images.githubusercontent.com/6045753/44047145-896b58ac-9f68-11e8-8dbe-fcddaba1a1fc.png">

We can set the span type by an attribute of [`span.type`](https://github.com/DataDog/dd-trace-go/blob/2ef32813748b754e58e3b9336fd257aec967515b/ddtrace/ext/tags.go#L34-L35), but ocsql cannot inject custom attributes now. I hope a type of the span sampled by ocsql is categorized as `DB`.

## WHAT

I implemented `WithDefaultAttributes()` and injected for each methods.