### PR TITLE
ocConn wrapping was hiding ConnBeginTx and ConnPrepareContext interfaces

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -13,10 +13,23 @@ import (
 	"go.opencensus.io/trace"
 )
 
+type connTx interface {
+	driver.Conn
+	driver.ConnBeginTx
+	driver.ConnPrepareContext
+}
+
 var (
 	regMu              sync.Mutex
 	attrMissingContext = trace.StringAttribute("ocsql.warning", "missing upstream context")
 	attrDeprecated     = trace.StringAttribute("ocsql.warning", "database driver uses deprecated features")
+
+	// Compile time assertions
+	_ driver.Driver        = &ocDriver{}
+	_ driver.DriverContext = &ocDriver{}
+	_ connTx               = &ocConn{}
+	_ driver.Result        = &ocResult{}
+	_ driver.Rows          = &ocRows{}
 )
 
 // Register initializes and registers our ocsql wrapped database driver

--- a/driver.go
+++ b/driver.go
@@ -25,11 +25,10 @@ var (
 	attrDeprecated     = trace.StringAttribute("ocsql.warning", "database driver uses deprecated features")
 
 	// Compile time assertions
-	_ driver.Driver        = &ocDriver{}
-	_ driver.DriverContext = &ocDriver{}
-	_ connTx               = &ocConn{}
-	_ driver.Result        = &ocResult{}
-	_ driver.Rows          = &ocRows{}
+	_ driver.Driver = &ocDriver{}
+	_ connTx        = &ocConn{}
+	_ driver.Result = &ocResult{}
+	_ driver.Rows   = &ocRows{}
 )
 
 // Register initializes and registers our ocsql wrapped database driver

--- a/driver_go1.10.go
+++ b/driver_go1.10.go
@@ -10,6 +10,9 @@ import (
 
 var ErrConnDone = sql.ErrConnDone
 
+// Compile time assertion
+var _ driver.DriverContext = &ocDriver{}
+
 // ocDriver implements driver.Driver
 type ocDriver struct {
 	parent    driver.Driver

--- a/driver_go1.10.go
+++ b/driver_go1.10.go
@@ -35,17 +35,17 @@ func wrapConn(parent driver.Conn, options TraceOptions) driver.Conn {
 		return c
 	case hasNameValueChecker && !hasSessionResetter:
 		return struct {
-			driver.Conn
+			connTx
 			driver.NamedValueChecker
 		}{c, n}
 	case !hasNameValueChecker && hasSessionResetter:
 		return struct {
-			driver.Conn
+			connTx
 			driver.SessionResetter
 		}{c, s}
 	case hasNameValueChecker && hasSessionResetter:
 		return struct {
-			driver.Conn
+			connTx
 			driver.NamedValueChecker
 			driver.SessionResetter
 		}{c, n, s}

--- a/driver_go1.9.go
+++ b/driver_go1.9.go
@@ -26,7 +26,7 @@ func wrapConn(c driver.Conn, options TraceOptions) driver.Conn {
 	conn := &ocConn{parent: c, options: options}
 	if hasNameValueChecker {
 		return struct {
-			driver.Conn
+			connTx
 			driver.NamedValueChecker
 		}{conn, n}
 	}


### PR DESCRIPTION
The struct wrapping logic of our ocConn implementation for the new enhancement interfaces was mistakenly hiding the ConnBeginTx and ConnPrepareContext interfaces.

This fixes #14.