### PR TITLE
unhide optional interfaces for Conn wrapping

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -13,10 +13,15 @@ import (
 	"go.opencensus.io/trace"
 )
 
-type connTx interface {
+type conn interface {
+	driver.Pinger
+	driver.Execer
+	driver.ExecerContext
+	driver.Queryer
+	driver.QueryerContext
 	driver.Conn
-	driver.ConnBeginTx
 	driver.ConnPrepareContext
+	driver.ConnBeginTx
 }
 
 var (
@@ -26,7 +31,7 @@ var (
 
 	// Compile time assertions
 	_ driver.Driver = &ocDriver{}
-	_ connTx        = &ocConn{}
+	_ conn          = &ocConn{}
 	_ driver.Result = &ocResult{}
 	_ driver.Rows   = &ocRows{}
 )
@@ -735,7 +740,7 @@ func setSpanStatus(span *trace.Span, err error) {
 		status.Code = trace.StatusCodeDeadlineExceeded
 	case sql.ErrNoRows:
 		status.Code = trace.StatusCodeNotFound
-	case sql.ErrTxDone, ErrConnDone:
+	case sql.ErrTxDone, errConnDone:
 		status.Code = trace.StatusCodeFailedPrecondition
 	default:
 		status.Code = trace.StatusCodeUnknown

--- a/driver_go1.10.go
+++ b/driver_go1.10.go
@@ -8,7 +8,7 @@ import (
 	"database/sql/driver"
 )
 
-var ErrConnDone = sql.ErrConnDone
+var errConnDone = sql.ErrConnDone
 
 // Compile time assertion
 var _ driver.DriverContext = &ocDriver{}
@@ -38,17 +38,17 @@ func wrapConn(parent driver.Conn, options TraceOptions) driver.Conn {
 		return c
 	case hasNameValueChecker && !hasSessionResetter:
 		return struct {
-			connTx
+			conn
 			driver.NamedValueChecker
 		}{c, n}
 	case !hasNameValueChecker && hasSessionResetter:
 		return struct {
-			connTx
+			conn
 			driver.SessionResetter
 		}{c, s}
 	case hasNameValueChecker && hasSessionResetter:
 		return struct {
-			connTx
+			conn
 			driver.NamedValueChecker
 			driver.SessionResetter
 		}{c, n, s}

--- a/driver_go1.8.go
+++ b/driver_go1.8.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Dummy error for setSpanStatus (does exist as sql.ErrConnDone in 1.9+)
-var ErrConnDone = errors.New("database/sql: connection is already closed")
+var errConnDone = errors.New("database/sql: connection is already closed")
 
 // ocDriver implements driver.Driver
 type ocDriver struct {

--- a/driver_go1.9.go
+++ b/driver_go1.9.go
@@ -7,7 +7,7 @@ import (
 	"database/sql/driver"
 )
 
-var ErrConnDone = sql.ErrConnDone
+var errConnDone = sql.ErrConnDone
 
 // ocDriver implements driver.Driver
 type ocDriver struct {
@@ -19,18 +19,18 @@ func wrapDriver(d driver.Driver, o TraceOptions) driver.Driver {
 	return ocDriver{parent: d, options: o}
 }
 
-func wrapConn(c driver.Conn, options TraceOptions) driver.Conn {
+func wrapConn(parent driver.Conn, options TraceOptions) driver.Conn {
 	var (
-		n, hasNameValueChecker = c.(driver.NamedValueChecker)
+		n, hasNameValueChecker = parent.(driver.NamedValueChecker)
 	)
-	conn := &ocConn{parent: c, options: options}
+	c := &ocConn{parent: parent, options: options}
 	if hasNameValueChecker {
 		return struct {
-			connTx
+			conn
 			driver.NamedValueChecker
-		}{conn, n}
+		}{c, n}
 	}
-	return conn
+	return c
 }
 
 func wrapStmt(stmt driver.Stmt, query string, options TraceOptions) driver.Stmt {


### PR DESCRIPTION
The following interfaces got hidden when wrapping ocConn:
- driver.Pinger
- driver.Execer
- driver.ExecerContext
- driver.Queryer
- driver.QueryerContext

These don't have to be conditional as either they can result in noop (Pinger) or return an driver.ErrSkip if wrapped implementation does not support them.

This should fix #17 