### PR TITLE
Add option to format span name with context

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -127,7 +127,8 @@ func (c ocConn) Ping(ctx context.Context) (err error) {
 
 	if c.options.Ping && (c.options.AllowRoot || trace.FromContext(ctx) != nil) {
 		var span *trace.Span
-		ctx, span = trace.StartSpan(ctx, "sql:ping", trace.WithSpanKind(trace.SpanKindClient))
+		ctx, span = trace.StartSpan(ctx, c.options.formatSpanName(ctx, "sql:ping"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		if len(c.options.DefaultAttributes) > 0 {
 			span.AddAttributes(c.options.DefaultAttributes...)
 		}
@@ -158,7 +159,8 @@ func (c ocConn) Exec(query string, args []driver.Value) (res driver.Result, err 
 			return exec.Exec(query, args)
 		}
 
-		ctx, span := trace.StartSpan(context.Background(), "sql:exec", trace.WithSpanKind(trace.SpanKindClient))
+		ctx, span := trace.StartSpan(context.Background(), c.options.formatSpanName(context.Background(), "sql:exec"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		attrs := make([]trace.Attribute, 0, len(c.options.DefaultAttributes)+2)
 		attrs = append(attrs, c.options.DefaultAttributes...)
 		attrs = append(
@@ -200,11 +202,12 @@ func (c ocConn) ExecContext(ctx context.Context, query string, args []driver.Nam
 			return execCtx.ExecContext(ctx, query, args)
 		}
 
+		spanName := c.options.formatSpanName(ctx, "sql:exec")
 		var span *trace.Span
 		if parentSpan == nil {
-			ctx, span = trace.StartSpan(ctx, "sql:exec", trace.WithSpanKind(trace.SpanKindClient))
+			ctx, span = trace.StartSpan(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
 		} else {
-			_, span = trace.StartSpan(ctx, "sql:exec", trace.WithSpanKind(trace.SpanKindClient))
+			_, span = trace.StartSpan(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
 		}
 		attrs := append([]trace.Attribute(nil), c.options.DefaultAttributes...)
 		if c.options.Query {
@@ -238,7 +241,8 @@ func (c ocConn) Query(query string, args []driver.Value) (rows driver.Rows, err 
 			return queryer.Query(query, args)
 		}
 
-		ctx, span := trace.StartSpan(context.Background(), "sql:query", trace.WithSpanKind(trace.SpanKindClient))
+		ctx, span := trace.StartSpan(context.Background(), c.options.formatSpanName(context.Background(), "sql:query"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		attrs := make([]trace.Attribute, 0, len(c.options.DefaultAttributes)+2)
 		attrs = append(attrs, c.options.DefaultAttributes...)
 		attrs = append(
@@ -283,9 +287,11 @@ func (c ocConn) QueryContext(ctx context.Context, query string, args []driver.Na
 
 		var span *trace.Span
 		if parentSpan == nil {
-			ctx, span = trace.StartSpan(ctx, "sql:query", trace.WithSpanKind(trace.SpanKindClient))
+			ctx, span = trace.StartSpan(ctx, c.options.formatSpanName(ctx, "sql:query"),
+				trace.WithSpanKind(trace.SpanKindClient))
 		} else {
-			_, span = trace.StartSpan(ctx, "sql:query", trace.WithSpanKind(trace.SpanKindClient))
+			_, span = trace.StartSpan(ctx, c.options.formatSpanName(ctx, "sql:query"),
+				trace.WithSpanKind(trace.SpanKindClient))
 		}
 		attrs := append([]trace.Attribute(nil), c.options.DefaultAttributes...)
 		if c.options.Query {
@@ -316,7 +322,8 @@ func (c ocConn) Prepare(query string) (stmt driver.Stmt, err error) {
 	defer recordCallStats(context.Background(), "go.sql.prepare")(err)
 
 	if c.options.AllowRoot {
-		_, span := trace.StartSpan(context.Background(), "sql:prepare", trace.WithSpanKind(trace.SpanKindClient))
+		_, span := trace.StartSpan(context.Background(), c.options.formatSpanName(context.Background(), "sql:prepare"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		attrs := make([]trace.Attribute, 0, len(c.options.DefaultAttributes)+1)
 		attrs = append(attrs, c.options.DefaultAttributes...)
 		attrs = append(attrs, attrMissingContext)
@@ -354,7 +361,8 @@ func (c *ocConn) PrepareContext(ctx context.Context, query string) (stmt driver.
 	var span *trace.Span
 	attrs := append([]trace.Attribute(nil), c.options.DefaultAttributes...)
 	if c.options.AllowRoot || trace.FromContext(ctx) != nil {
-		ctx, span = trace.StartSpan(ctx, "sql:prepare", trace.WithSpanKind(trace.SpanKindClient))
+		ctx, span = trace.StartSpan(ctx, c.options.formatSpanName(ctx, "sql:prepare"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		if c.options.Query {
 			attrs = append(attrs, trace.StringAttribute("sql.query", query))
 		}
@@ -396,11 +404,10 @@ func (c *ocConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.
 
 	if ctx == nil || ctx == context.TODO() {
 		ctx = context.Background()
-		_, span = trace.StartSpan(ctx, "sql:begin_transaction", trace.WithSpanKind(trace.SpanKindClient))
 		attrs = append(attrs, attrMissingContext)
-	} else {
-		_, span = trace.StartSpan(ctx, "sql:begin_transaction", trace.WithSpanKind(trace.SpanKindClient))
 	}
+	_, span = trace.StartSpan(ctx, c.options.formatSpanName(ctx, "sql:begin_transaction"),
+		trace.WithSpanKind(trace.SpanKindClient))
 	defer func() {
 		if len(attrs) > 0 {
 			span.AddAttributes(attrs...)
@@ -441,7 +448,8 @@ type ocResult struct {
 
 func (r ocResult) LastInsertId() (id int64, err error) {
 	if r.options.LastInsertID {
-		_, span := trace.StartSpan(r.ctx, "sql:last_insert_id", trace.WithSpanKind(trace.SpanKindClient))
+		_, span := trace.StartSpan(r.ctx, r.options.formatSpanName(r.ctx, "sql:last_insert_id"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		if len(r.options.DefaultAttributes) > 0 {
 			span.AddAttributes(r.options.DefaultAttributes...)
 		}
@@ -457,7 +465,8 @@ func (r ocResult) LastInsertId() (id int64, err error) {
 
 func (r ocResult) RowsAffected() (cnt int64, err error) {
 	if r.options.RowsAffected {
-		_, span := trace.StartSpan(r.ctx, "sql:rows_affected", trace.WithSpanKind(trace.SpanKindClient))
+		_, span := trace.StartSpan(r.ctx, r.options.formatSpanName(r.ctx, "sql:rows_affected"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		if len(r.options.DefaultAttributes) > 0 {
 			span.AddAttributes(r.options.DefaultAttributes...)
 		}
@@ -485,7 +494,8 @@ func (s ocStmt) Exec(args []driver.Value) (res driver.Result, err error) {
 		return s.parent.Exec(args)
 	}
 
-	ctx, span := trace.StartSpan(context.Background(), "sql:exec", trace.WithSpanKind(trace.SpanKindClient))
+	ctx, span := trace.StartSpan(context.Background(), s.options.formatSpanName(context.Background(), "sql:exec"),
+		trace.WithSpanKind(trace.SpanKindClient))
 	attrs := make([]trace.Attribute, 0, len(s.options.DefaultAttributes)+2)
 	attrs = append(attrs, s.options.DefaultAttributes...)
 	attrs = append(
@@ -532,7 +542,8 @@ func (s ocStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 		return s.parent.Query(args)
 	}
 
-	ctx, span := trace.StartSpan(context.Background(), "sql:query", trace.WithSpanKind(trace.SpanKindClient))
+	ctx, span := trace.StartSpan(context.Background(), s.options.formatSpanName(context.Background(), "sql:query"),
+		trace.WithSpanKind(trace.SpanKindClient))
 	attrs := make([]trace.Attribute, 0, len(s.options.DefaultAttributes)+2)
 	attrs = append(attrs, s.options.DefaultAttributes...)
 	attrs = append(
@@ -572,11 +583,12 @@ func (s ocStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res 
 		return s.parent.(driver.StmtExecContext).ExecContext(ctx, args)
 	}
 
+	spanName := s.options.formatSpanName(ctx, "sql:exec")
 	var span *trace.Span
 	if parentSpan == nil {
-		ctx, span = trace.StartSpan(ctx, "sql:exec", trace.WithSpanKind(trace.SpanKindClient))
+		ctx, span = trace.StartSpan(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
 	} else {
-		_, span = trace.StartSpan(ctx, "sql:exec", trace.WithSpanKind(trace.SpanKindClient))
+		_, span = trace.StartSpan(ctx, spanName, trace.WithSpanKind(trace.SpanKindClient))
 	}
 	attrs := append([]trace.Attribute(nil), s.options.DefaultAttributes...)
 	if s.options.Query {
@@ -613,9 +625,11 @@ func (s ocStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (row
 
 	var span *trace.Span
 	if parentSpan == nil {
-		ctx, span = trace.StartSpan(ctx, "sql:query", trace.WithSpanKind(trace.SpanKindClient))
+		ctx, span = trace.StartSpan(ctx, s.options.formatSpanName(ctx, "sql:query"),
+			trace.WithSpanKind(trace.SpanKindClient))
 	} else {
-		_, span = trace.StartSpan(ctx, "sql:query", trace.WithSpanKind(trace.SpanKindClient))
+		_, span = trace.StartSpan(ctx, s.options.formatSpanName(ctx, "sql:query"),
+			trace.WithSpanKind(trace.SpanKindClient))
 	}
 	attrs := append([]trace.Attribute(nil), s.options.DefaultAttributes...)
 	if s.options.Query {
@@ -730,7 +744,8 @@ func (r ocRows) Columns() []string {
 
 func (r ocRows) Close() (err error) {
 	if r.options.RowsClose {
-		_, span := trace.StartSpan(r.ctx, "sql:rows_close", trace.WithSpanKind(trace.SpanKindClient))
+		_, span := trace.StartSpan(r.ctx, r.options.formatSpanName(r.ctx, "sql:rows_close"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		if len(r.options.DefaultAttributes) > 0 {
 			span.AddAttributes(r.options.DefaultAttributes...)
 		}
@@ -746,7 +761,8 @@ func (r ocRows) Close() (err error) {
 
 func (r ocRows) Next(dest []driver.Value) (err error) {
 	if r.options.RowsNext {
-		_, span := trace.StartSpan(r.ctx, "sql:rows_next", trace.WithSpanKind(trace.SpanKindClient))
+		_, span := trace.StartSpan(r.ctx, r.options.formatSpanName(r.ctx, "sql:rows_next"),
+			trace.WithSpanKind(trace.SpanKindClient))
 		if len(r.options.DefaultAttributes) > 0 {
 			span.AddAttributes(r.options.DefaultAttributes...)
 		}
@@ -802,7 +818,8 @@ type ocTx struct {
 func (t ocTx) Commit() (err error) {
 	defer recordCallStats(context.Background(), "go.sql.commit")(err)
 
-	_, span := trace.StartSpan(t.ctx, "sql:commit", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := trace.StartSpan(t.ctx, t.options.formatSpanName(t.ctx, "sql:commit"),
+		trace.WithSpanKind(trace.SpanKindClient))
 	if len(t.options.DefaultAttributes) > 0 {
 		span.AddAttributes(t.options.DefaultAttributes...)
 	}
@@ -818,7 +835,8 @@ func (t ocTx) Commit() (err error) {
 func (t ocTx) Rollback() (err error) {
 	defer recordCallStats(context.Background(), "go.sql.rollback")(err)
 
-	_, span := trace.StartSpan(t.ctx, "sql:rollback", trace.WithSpanKind(trace.SpanKindClient))
+	_, span := trace.StartSpan(t.ctx, t.options.formatSpanName(t.ctx, "sql:rollback"),
+		trace.WithSpanKind(trace.SpanKindClient))
 	if len(t.options.DefaultAttributes) > 0 {
 		span.AddAttributes(t.options.DefaultAttributes...)
 	}


### PR DESCRIPTION
This PR adds option to format span name with `func(ctx context.Context, baseName string) string`. 

That can be handy to make spans more relevant to application flow and enable precise tracing. 
Somewhat similar approach is used in [`ochttp.Handler`](https://godoc.org/go.opencensus.io/plugin/ochttp#Handler):
```
    // FormatSpanName holds the function to use for generating the span name
    // from the information found in the incoming HTTP Request. By default the
    // name equals the URL Path.
    FormatSpanName func(*http.Request) string
```
