### PR TITLE
Fix span attributes & option propagation for transaction related spans

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -413,7 +413,7 @@ func (c *ocConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.
 		if err != nil {
 			return nil, err
 		}
-		return ocTx{parent: tx, ctx: ctx}, nil
+		return ocTx{parent: tx, ctx: ctx, options: c.options}, nil
 	}
 
 	attrs = append(
@@ -428,7 +428,7 @@ func (c *ocConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.
 	if err != nil {
 		return nil, err
 	}
-	return ocTx{parent: tx, ctx: ctx}, nil
+	return ocTx{parent: tx, ctx: ctx, options: c.options}, nil
 }
 
 // ocResult implements driver.Result


### PR DESCRIPTION
I noticed a couple of bugs when using this package: 

- All span attributes are missing from `sql:begin_transaction` due to the execution order of multiple defers
- All transaction spans are missing `TraceOptions` 

