### PR TITLE
Add DisableErrSkip option to span status

### DIFF
--- a/options.go
+++ b/options.go
@@ -50,6 +50,9 @@ type TraceOptions struct {
 
 	// DefaultAttributes will be set to each span as default.
 	DefaultAttributes []trace.Attribute
+
+	// DisableErrSkip, if set to true, will suppress driver.ErrSkip errors in spans.
+	DisableErrSkip bool
 }
 
 // WithAllTraceOptions enables all available trace options.
@@ -154,5 +157,12 @@ func WithQueryParams(b bool) TraceOption {
 func WithDefaultAttributes(attrs ...trace.Attribute) TraceOption {
 	return func(o *TraceOptions) {
 		o.DefaultAttributes = attrs
+	}
+}
+
+// WithDisableErrSkip, if set to true, will suppress driver.ErrSkip errors in spans.
+func WithDisableErrSkip(b bool) TraceOption {
+	return func(o *TraceOptions) {
+		o.DisableErrSkip = b
 	}
 }


### PR DESCRIPTION
Adding a `DisableErrSkip` option to `TraceOptions` in order to be able to suppress [`driver.ErrSkip`](https://golang.org/pkg/database/sql/driver/#ErrSkip) errors in spans.

Right now, it's really annoying to see many "non-real failures" reporting in the tracing dashboard (many spans with `status != 0`), since `ocsql` sets the span's status to non zero when the error is [`driver.ErrSkip`](https://golang.org/pkg/database/sql/driver/#ErrSkip), which is not a real failure.

I'm keeping the behavior backward compatible by disabling the error reporting only when this option is being set explicitly.

Attaching here screenshots with before/after:
- Before:
<img width="914" alt="before1" src="https://user-images.githubusercontent.com/7413593/59982208-52dadc80-9617-11e9-8e28-cd6d988a72c6.png">
<img width="1061" alt="before2" src="https://user-images.githubusercontent.com/7413593/59982207-52dadc80-9617-11e9-85b9-e015f869b6ec.png">

- After - spans with `driver.ErrSkip` still hold the message, but are not reported as errors:
<img width="1253" alt="after 1" src="https://user-images.githubusercontent.com/7413593/59982239-b9f89100-9617-11e9-8a7c-b3ea1f0e0bbf.png">


Awesome package, thanks for creating this. 
