### PR TITLE
Add InstanceName trace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var (
 )
 
 // Register our ocsql wrapper for the provided SQLite3 driver.
-driverName, err = ocsql.Register("sqlite3", ocsql.WithAllTraceOptions())
+driverName, err = ocsql.Register("sqlite3", ocsql.WithAllTraceOptions(), ocsql.WithInstanceName("resources"))
 if err != nil {
     log.Fatalf("unable to register our ocsql driver: %v\n", err)
 }

--- a/driver.go
+++ b/driver.go
@@ -94,6 +94,7 @@ func Wrap(d driver.Driver, options ...TraceOption) driver.Driver {
 	for _, option := range options {
 		option(&o)
 	}
+	o.DefaultAttributes = append(o.DefaultAttributes, trace.StringAttribute("sql.instance", o.InstanceName))
 	if o.QueryParams && !o.Query {
 		o.QueryParams = false
 	}
@@ -117,6 +118,7 @@ func WrapConn(c driver.Conn, options ...TraceOption) driver.Conn {
 	for _, option := range options {
 		option(&o)
 	}
+	o.DefaultAttributes = append(o.DefaultAttributes, trace.StringAttribute("sql.instance", o.InstanceName))
 	return wrapConn(c, o)
 }
 

--- a/driver.go
+++ b/driver.go
@@ -88,13 +88,15 @@ func Register(driverName string, options ...TraceOption) (string, error) {
 
 // Wrap takes a SQL driver and wraps it with OpenCensus instrumentation.
 func Wrap(d driver.Driver, options ...TraceOption) driver.Driver {
-	o := TraceOptions{
-		InstanceName: defaultInstanceName,
-	}
+	o := TraceOptions{}
 	for _, option := range options {
 		option(&o)
 	}
-	o.DefaultAttributes = append(o.DefaultAttributes, trace.StringAttribute("sql.instance", o.InstanceName))
+	if o.InstanceName == "" {
+		o.InstanceName = defaultInstanceName
+	} else {
+		o.DefaultAttributes = append(o.DefaultAttributes, trace.StringAttribute("sql.instance", o.InstanceName))
+	}
 	if o.QueryParams && !o.Query {
 		o.QueryParams = false
 	}
@@ -112,13 +114,15 @@ func (d ocDriver) Open(name string) (driver.Conn, error) {
 
 // WrapConn allows an existing driver.Conn to be wrapped by ocsql.
 func WrapConn(c driver.Conn, options ...TraceOption) driver.Conn {
-	o := TraceOptions{
-		InstanceName: defaultInstanceName,
-	}
+	o := TraceOptions{}
 	for _, option := range options {
 		option(&o)
 	}
-	o.DefaultAttributes = append(o.DefaultAttributes, trace.StringAttribute("sql.instance", o.InstanceName))
+	if o.InstanceName == "" {
+		o.InstanceName = defaultInstanceName
+	} else {
+		o.DefaultAttributes = append(o.DefaultAttributes, trace.StringAttribute("sql.instance", o.InstanceName))
+	}
 	return wrapConn(c, o)
 }
 

--- a/driver_go1.10.go
+++ b/driver_go1.10.go
@@ -19,7 +19,9 @@ var (
 // WrapConnector allows wrapping a database driver.Connector which eliminates
 // the need to register ocsql as an available driver.Driver.
 func WrapConnector(dc driver.Connector, options ...TraceOption) driver.Connector {
-	opts := TraceOptions{}
+	opts := TraceOptions{
+		InstanceName: defaultInstanceName,
+	}
 	for _, o := range options {
 		o(&opts)
 	}

--- a/driver_go1.10.go
+++ b/driver_go1.10.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+
+	"go.opencensus.io/trace"
 )
 
 var errConnDone = sql.ErrConnDone
@@ -25,6 +27,10 @@ func WrapConnector(dc driver.Connector, options ...TraceOption) driver.Connector
 	for _, o := range options {
 		o(&opts)
 	}
+	opts.DefaultAttributes = append(
+		opts.DefaultAttributes,
+		trace.StringAttribute("sql.instance", opts.InstanceName),
+	)
 
 	return &ocDriver{
 		parent:    dc.Driver(),

--- a/driver_go1.10.go
+++ b/driver_go1.10.go
@@ -21,21 +21,20 @@ var (
 // WrapConnector allows wrapping a database driver.Connector which eliminates
 // the need to register ocsql as an available driver.Driver.
 func WrapConnector(dc driver.Connector, options ...TraceOption) driver.Connector {
-	opts := TraceOptions{
-		InstanceName: defaultInstanceName,
+	o := TraceOptions{}
+	for _, option := range options {
+		option(&o)
 	}
-	for _, o := range options {
-		o(&opts)
+	if o.InstanceName == "" {
+		o.InstanceName = defaultInstanceName
+	} else {
+		o.DefaultAttributes = append(o.DefaultAttributes, trace.StringAttribute("sql.instance", o.InstanceName))
 	}
-	opts.DefaultAttributes = append(
-		opts.DefaultAttributes,
-		trace.StringAttribute("sql.instance", opts.InstanceName),
-	)
 
 	return &ocDriver{
 		parent:    dc.Driver(),
 		connector: dc,
-		options:   opts,
+		options:   o,
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -7,6 +7,8 @@ import (
 // TraceOption allows for managing ocsql configuration using functional options.
 type TraceOption func(o *TraceOptions)
 
+const defaultInstanceName = "default"
+
 // TraceOptions holds configuration of our ocsql tracing middleware.
 // By default all options are set to false intentionally when creating a wrapped
 // driver and provide the most sensible default with both performance and
@@ -50,6 +52,9 @@ type TraceOptions struct {
 
 	// DefaultAttributes will be set to each span as default.
 	DefaultAttributes []trace.Attribute
+
+	// InstanceName identifies database.
+	InstanceName string
 
 	// DisableErrSkip, if set to true, will suppress driver.ErrSkip errors in spans.
 	DisableErrSkip bool
@@ -164,5 +169,12 @@ func WithDefaultAttributes(attrs ...trace.Attribute) TraceOption {
 func WithDisableErrSkip(b bool) TraceOption {
 	return func(o *TraceOptions) {
 		o.DisableErrSkip = b
+	}
+}
+
+// WithInstanceName sets database instance name.
+func WithInstanceName(instanceName string) TraceOption {
+	return func(o *TraceOptions) {
+		o.InstanceName = instanceName
 	}
 }


### PR DESCRIPTION
This PR adds TraceOption to define database instance name so that traces and metrics can be separated when multiple instances are being used. 

Resolves https://github.com/opencensus-integrations/ocsql/issues/33.