### PR TITLE
initializer: add RegisterWithSource to allow pass in dataSourceName to sql.Open

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -51,8 +51,18 @@ var (
 // It is possible to register multiple wrappers for the same database driver if
 // needing different TraceOptions for different connections.
 func Register(driverName string, options ...TraceOption) (string, error) {
+	return RegisterWithSource(driverName, "", options...)
+}
+
+// RegisterWithSource initializes and registers our ocsql wrapped database driver
+// identified by its driverName, using provided TraceOptions.
+// source is useful if some drivers do not accept the empty string when opening the DB.
+// On success it returns the generated driverName to use when calling sql.Open.
+// It is possible to register multiple wrappers for the same database driver if
+// needing different TraceOptions for different connections.
+func RegisterWithSource(driverName string, source string, options ...TraceOption) (string, error) {
 	// retrieve the driver implementation we need to wrap with instrumentation
-	db, err := sql.Open(driverName, "")
+	db, err := sql.Open(driverName, source)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Adds an initializing function RegisterWithSource that allows the dataSourceName to
be passed into database/sql.Open. This option is important for backends such as
goracle and godor, lest they return an initialization error.

Fixes #41