### PR TITLE
observability: fix err access scope to correctly retrieve it on defer

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -133,7 +133,12 @@ type ocConn struct {
 }
 
 func (c ocConn) Ping(ctx context.Context) (err error) {
-	defer recordCallStats(ctx, "go.sql.ping", c.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(ctx, "go.sql.ping", c.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if c.options.Ping && (c.options.AllowRoot || trace.FromContext(ctx) != nil) {
 		var span *trace.Span
@@ -164,7 +169,12 @@ func (c ocConn) Ping(ctx context.Context) (err error) {
 }
 
 func (c ocConn) Exec(query string, args []driver.Value) (res driver.Result, err error) {
-	defer recordCallStats(context.Background(), "go.sql.exec", c.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(context.Background(), "go.sql.exec", c.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if exec, ok := c.parent.(driver.Execer); ok {
 		if !c.options.AllowRoot {
@@ -208,7 +218,12 @@ func (c ocConn) Exec(query string, args []driver.Value) (res driver.Result, err 
 }
 
 func (c ocConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (res driver.Result, err error) {
-	defer recordCallStats(ctx, "go.sql.exec", c.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(ctx, "go.sql.exec", c.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if execCtx, ok := c.parent.(driver.ExecerContext); ok {
 		parentSpan := trace.FromContext(ctx)
@@ -253,7 +268,12 @@ func (c ocConn) ExecContext(ctx context.Context, query string, args []driver.Nam
 }
 
 func (c ocConn) Query(query string, args []driver.Value) (rows driver.Rows, err error) {
-	defer recordCallStats(context.Background(), "go.sql.query", c.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(context.Background(), "go.sql.query", c.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if queryer, ok := c.parent.(driver.Queryer); ok {
 		if !c.options.AllowRoot {
@@ -298,7 +318,12 @@ func (c ocConn) Query(query string, args []driver.Value) (rows driver.Rows, err 
 }
 
 func (c ocConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (rows driver.Rows, err error) {
-	defer recordCallStats(ctx, "go.sql.query", c.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(ctx, "go.sql.query", c.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if queryerCtx, ok := c.parent.(driver.QueryerContext); ok {
 		parentSpan := trace.FromContext(ctx)
@@ -344,7 +369,12 @@ func (c ocConn) QueryContext(ctx context.Context, query string, args []driver.Na
 }
 
 func (c ocConn) Prepare(query string) (stmt driver.Stmt, err error) {
-	defer recordCallStats(context.Background(), "go.sql.prepare", c.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(context.Background(), "go.sql.prepare", c.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if c.options.AllowRoot {
 		_, span := trace.StartSpan(context.Background(), "sql:prepare",
@@ -383,7 +413,12 @@ func (c *ocConn) Begin() (driver.Tx, error) {
 }
 
 func (c *ocConn) PrepareContext(ctx context.Context, query string) (stmt driver.Stmt, err error) {
-	defer recordCallStats(ctx, "go.sql.prepare", c.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(ctx, "go.sql.prepare", c.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	var span *trace.Span
 	attrs := append([]trace.Attribute(nil), c.options.DefaultAttributes...)
@@ -419,7 +454,12 @@ func (c *ocConn) PrepareContext(ctx context.Context, query string) (stmt driver.
 }
 
 func (c *ocConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.Tx, err error) {
-	defer recordCallStats(ctx, "go.sql.begin", c.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(ctx, "go.sql.begin", c.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if !c.options.AllowRoot && trace.FromContext(ctx) == nil {
 		if connBeginTx, ok := c.parent.(driver.ConnBeginTx); ok {
@@ -528,7 +568,12 @@ type ocStmt struct {
 }
 
 func (s ocStmt) Exec(args []driver.Value) (res driver.Result, err error) {
-	defer recordCallStats(context.Background(), "go.sql.stmt.exec", s.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(context.Background(), "go.sql.stmt.exec", s.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if !s.options.AllowRoot {
 		return s.parent.Exec(args)
@@ -578,7 +623,12 @@ func (s ocStmt) NumInput() int {
 }
 
 func (s ocStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
-	defer recordCallStats(context.Background(), "go.sql.stmt.query", s.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(context.Background(), "go.sql.stmt.query", s.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	if !s.options.AllowRoot {
 		return s.parent.Query(args)
@@ -619,7 +669,12 @@ func (s ocStmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 }
 
 func (s ocStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res driver.Result, err error) {
-	defer recordCallStats(ctx, "go.sql.stmt.exec", s.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(ctx, "go.sql.stmt.exec", s.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	parentSpan := trace.FromContext(ctx)
 	if !s.options.AllowRoot && parentSpan == nil {
@@ -664,7 +719,12 @@ func (s ocStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (res 
 }
 
 func (s ocStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (rows driver.Rows, err error) {
-	defer recordCallStats(ctx, "go.sql.stmt.query", s.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(ctx, "go.sql.stmt.query", s.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	parentSpan := trace.FromContext(ctx)
 	if !s.options.AllowRoot && parentSpan == nil {
@@ -873,7 +933,12 @@ type ocTx struct {
 }
 
 func (t ocTx) Commit() (err error) {
-	defer recordCallStats(context.Background(), "go.sql.commit", t.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(context.Background(), "go.sql.commit", t.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	_, span := trace.StartSpan(t.ctx, "sql:commit",
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -892,7 +957,12 @@ func (t ocTx) Commit() (err error) {
 }
 
 func (t ocTx) Rollback() (err error) {
-	defer recordCallStats(context.Background(), "go.sql.rollback", t.options.InstanceName)(err)
+	onDeferWithErr := recordCallStats(context.Background(), "go.sql.rollback", t.options.InstanceName)
+	defer func() {
+		// Invoking this function in a defer so that we can capture
+		// the value of err as set on function exit.
+		onDeferWithErr(err)
+	}()
 
 	_, span := trace.StartSpan(t.ctx, "sql:rollback",
 		trace.WithSpanKind(trace.SpanKindClient),


### PR DESCRIPTION
Ensure the final `err` value is reported to recordCallStats' annonymous function instead of `nil`.

Stats were always reporting `GoSQLStatus` as `OK` even when queries failed. This change will allow the status to be `ERROR` and for `GoSQLError` to be populated.