### PR TITLE
Assign converted value instead of discarding.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -516,12 +516,12 @@ func (c *ocConn) BeginTx(ctx context.Context, opts driver.TxOptions) (tx driver.
 	return ocTx{parent: tx, ctx: ctx, options: c.options}, nil
 }
 
-func (c *ocConn) CheckNamedValue(nv *driver.NamedValue) error {
+func (c *ocConn) CheckNamedValue(nv *driver.NamedValue) (err error) {
 	nvc, ok := c.parent.(driver.NamedValueChecker)
 	if ok {
 		return nvc.CheckNamedValue(nv)
 	}
-	_, err := driver.DefaultParameterConverter.ConvertValue(nv.Value)
+	nv.Value, err = driver.DefaultParameterConverter.ConvertValue(nv.Value)
 	return err
 }
 


### PR DESCRIPTION
This fixes a bug in 7dada5eac4570cfbfb474715416f7f54f065a153 which
breaks all drivers that do not implement the NamedValueConverter
interface.