### PR TITLE
Added support for custom span names

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,6 +1,8 @@
 package ocsql
 
 import (
+	"context"
+
 	"go.opencensus.io/trace"
 )
 
@@ -61,6 +63,11 @@ type TraceOptions struct {
 
 	// Sampler to use when creating spans.
 	Sampler trace.Sampler
+
+	// FormatSpanName allows you to overwrite the default span name with a custom name from the context
+	// This only works with operations using context
+	// Will use default name if left nil.
+	FormatSpanName func(context.Context) string
 }
 
 // WithAllTraceOptions enables all available trace options.
@@ -168,7 +175,7 @@ func WithDefaultAttributes(attrs ...trace.Attribute) TraceOption {
 	}
 }
 
-// WithDisableErrSkip, if set to true, will suppress driver.ErrSkip errors in spans.
+// WithDisableErrSkip if set to true, will suppress driver.ErrSkip errors in spans.
 func WithDisableErrSkip(b bool) TraceOption {
 	return func(o *TraceOptions) {
 		o.DisableErrSkip = b

--- a/options.go
+++ b/options.go
@@ -195,3 +195,10 @@ func WithInstanceName(instanceName string) TraceOption {
 		o.InstanceName = instanceName
 	}
 }
+
+// WithFormatSpanName sets the FormatSpanName func
+func WithFormatSpanName(spanFunc func(context.Context) string) TraceOption {
+	return func(o *TraceOptions) {
+		o.FormatSpanName = spanFunc
+	}
+}


### PR DESCRIPTION
We would like to have the ability to customize the names of the spans created on sql operations. I've added the following to be able to set the span name without any changes needed to codebases already using the library.

Added an option to TraceOptions struct to allow us to set custom span names from context.
Updated all context client operations to support using the FormatSpanName func to set the custom span name. 
Added a WithFormatSpanName func to functionally set the FormatSpanName option.